### PR TITLE
encodes periods in varids

### DIFF
--- a/kastle-foundry.py
+++ b/kastle-foundry.py
@@ -267,7 +267,7 @@ def apply_mapping(row, mapping, graph):
         varid_vals = list()
         for varid in varids:
             try:
-                varid_vals.append(quote(row[varid], safe=""))
+                varid_vals.append(quote(row[varid], safe="").replace(".", "%2E"))
             except KeyError:
                 msg = "Variable ID missing from data file"
                 log_message_with_node(msg, mapping, error_type="error")


### PR DESCRIPTION
As an alternative to hashing, due to the major cons of human readability and increased collision, simply replacing "." with its encoding values fixes the issue in #12 .